### PR TITLE
Match version tags starting with leading v

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
         run: go build
 
       - name: Check that all tests pass
-        run: go test
+        run: go test -v

--- a/main.go
+++ b/main.go
@@ -23,14 +23,20 @@ var (
 )
 
 const versionPattern = "[0-9]*.[0-9]*.[0-9]*"
+const prefixedVersionPattern = "v[0-9]*.[0-9]*.[0-9]*"
 const timeShasumPattern = "[0-9]*-[0-9a-f]*"
 
 func scanForJobs(ctx context.Context, jobs chan<- Job, root string) error {
 	patterns := []string{
-		filepath.Join(root, "node-*", "uploads", "*", versionPattern, timeShasumPattern, "data"),      // uploads without a namespace
-		filepath.Join(root, "node-*", "uploads", "*", "latest", timeShasumPattern, "data"),            // uploads without a namespace (latest tag)
-		filepath.Join(root, "node-*", "uploads", "*", "*", versionPattern, timeShasumPattern, "data"), // uploads with a namespace
-		filepath.Join(root, "node-*", "uploads", "*", "*", "latest", timeShasumPattern, "data"),       // uploads with a namespace (latest tag)
+		// without namespace
+		filepath.Join(root, "node-*", "uploads", "*", versionPattern, timeShasumPattern, "data"),         // version
+		filepath.Join(root, "node-*", "uploads", "*", prefixedVersionPattern, timeShasumPattern, "data"), // prefixed version
+		filepath.Join(root, "node-*", "uploads", "*", "latest", timeShasumPattern, "data"),               // latest tag
+
+		// with namespace
+		filepath.Join(root, "node-*", "uploads", "*", "*", versionPattern, timeShasumPattern, "data"),         // version
+		filepath.Join(root, "node-*", "uploads", "*", "*", prefixedVersionPattern, timeShasumPattern, "data"), // prefixed version
+		filepath.Join(root, "node-*", "uploads", "*", "*", "latest", timeShasumPattern, "data"),               // latest tag
 	}
 
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {

--- a/worker_test.go
+++ b/worker_test.go
@@ -86,6 +86,18 @@ func TestScanAndProcess(t *testing.T) {
 				data:   []byte(`{"ts":1638576647406523064,"labels":{"filename":"wow1.txt"}}`),
 			},
 		},
+		"DefaultSageJobLeadingV": {
+			{
+				path:   "node-000048b02d15bc7c/uploads/imagesampler-top/v0.2.5/1638576647406523064-9801739daae44ec5293d4e1f53d3f4d2d426d91c/data",
+				upload: "node-data/sage/sage-imagesampler-top-v0.2.5/000048b02d15bc7c/1638576647406523064-wow1.txt",
+				data:   []byte(`some data`),
+			},
+			{
+				path:   "node-000048b02d15bc7c/uploads/imagesampler-top/v0.2.5/1638576647406523064-9801739daae44ec5293d4e1f53d3f4d2d426d91c/meta",
+				upload: "node-data/sage/sage-imagesampler-top-v0.2.5/000048b02d15bc7c/1638576647406523064-wow1.txt.meta",
+				data:   []byte(`{"ts":1638576647406523064,"labels":{"filename":"wow1.txt"}}`),
+			},
+		},
 		"Job": {
 			{
 				path:   "node-000048b02d15bc7c/uploads/Pluginctl/imagesampler-top/0.2.5/1638576647406523064-9801739daae44ec5293d4e1f53d3f4d2d426d91c/data",


### PR DESCRIPTION
One of our users is prefixing version tag with a leading v which wasn't considered valid.

This is common enough, that I'm adding support for it. In total, we now match tags:
* x.y.z
* vx.y.z
* latest