### PR TITLE
Added Pelican as a Storage configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 sage-storage-loader
 test-data/
+token

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ docker-compose up -d --build
 docker-compose logs -f
 ```
 
-'issuer-key.pem' for use with Pelican can be generated using the [SciTokens](https://scitokens.org) Python library and tools. More information can be found here [Pelican Config](https://github.com/waggle-sensor/honeyhouse-config/tree/main/beehives/sage-beehive/config/pelican).
+'issuer-key.pem' for use with Pelican can be retrieved here [Pelican Config](https://github.com/waggle-sensor/honeyhouse-config/tree/main/beehives/sage-beehive/config/pelican) or generated using the [SciTokens](https://scitokens.org) Python library and tools. More information can be found here [Pelican Config](https://github.com/waggle-sensor/honeyhouse-config/tree/main/beehives/sage-beehive/config/pelican).
 
 Test uploads can be generated using `tools/generate-data-dir.py`.
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ docker-compose up -d --build
 docker-compose logs -f
 ```
 
+'issuer-key.pem' for use with Pelican can be generated using the [SciTokens](https://scitokens.org) Python library and tools. More information can be found here [Pelican Config](https://github.com/waggle-sensor/honeyhouse-config/tree/main/beehives/sage-beehive/config/pelican).
+
 Test uploads can be generated using `tools/generate-data-dir.py`.
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Sage Storage Loader
 
-This service loads files staged in a directory (on Beehive) into [OSN](https://www.openstoragenetwork.org/) or [Pelican](https://pelicanplatform.org/). Based on LoaderConfig.Config it will use OSN or Pelican.
-**main.go is configured to use Pelican*
+This service loads files staged in a directory (on Beehive) into [OSN](https://www.openstoragenetwork.org/) or [Pelican](https://pelicanplatform.org/). Based on env variable **STORAGE_TYPE** it will use OSN or Pelican.
 
 The expected data flow is:
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ docker-compose up -d --build
 docker-compose logs -f
 ```
 
-Test uploads can be generated using `tools/generate-data-dir.py`. *Make sure you move the test data to `/test/s3`*
+Test uploads can be generated using `tools/generate-data-dir.py`.
 
 ```sh
-# generate 100 test uploads into the default test-data dir
-python3 tools/generate-data-dir.py 100
+# generate 100 test uploads
+python3 tools/generate-data-dir.py --data-dir test/s3/test-data 100
 ```
 
 You can open the Minio UI at [http://localhost:9001](http://localhost:9001).
@@ -50,11 +50,11 @@ docker-compose up -d --build
 docker-compose logs -f
 ```
 
-Test uploads can be generated using `tools/generate-data-dir.py`. *Make sure you move the test data to `/test/s3`*
+Test uploads can be generated using `tools/generate-data-dir.py`.
 
 ```sh
-# generate 10 test uploads into the default test-data dir
-python3 tools/generate-data-dir.py 10
+# generate 10 test uploads
+python3 tools/generate-data-dir.py --data-dir test/pelican/test-data 10
 ```
 
 You can check the uploads by curling for them in **LOADER_PELICAN_ENDPOINT**. For example:

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ The expected data flow is:
 
 # Integration testing for OSN with Minio
 
-We can stand up an integration testing environment using Docker Compose:
+We can stand up an integration testing environment using Docker Compose in `/test/s3`:
 
 ```sh
 docker-compose up -d --build
 docker-compose logs -f
 ```
 
-Test uploads can be generated using `tools/generate-data-dir.py`.
+Test uploads can be generated using `tools/generate-data-dir.py`. *Make sure you move the test data to `/test/s3`*
 
 ```sh
 # generate 100 test uploads into the default test-data dir
@@ -40,3 +40,26 @@ python3 tools/generate-data-dir.py 100
 ```
 
 You can open the Minio UI at [http://localhost:9001](http://localhost:9001).
+
+# Integration testing for Pelican
+
+We can stand up an integration testing environment using Docker Compose in `/test/pelican`:
+
+```sh
+docker-compose up -d --build
+docker-compose logs -f
+```
+
+Test uploads can be generated using `tools/generate-data-dir.py`. *Make sure you move the test data to `/test/s3`*
+
+```sh
+# generate 10 test uploads into the default test-data dir
+python3 tools/generate-data-dir.py 10
+```
+
+You can check the uploads by curling for them in **LOADER_PELICAN_ENDPOINT**. For example:
+
+```sh
+#create jwt token first then run:
+curl -v -H "Authorization: Bearer $(cat token)" $(LOADER_PELICAN_ENDPOINT)/$(LOADER_PELICAN_BUCKET)/
+```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Sage Storage Loader
 
-This service loads files staged in a directory (on Beehive) into OSN.
+This service loads files staged in a directory (on Beehive) into [OSN](https://www.openstoragenetwork.org/) or [Pelican](https://pelicanplatform.org/). Based on LoaderConfig.Config it will use OSN or Pelican.
+**main.go is configured to use Pelican*
 
 The expected data flow is:
 
 ```txt
           rsync uploads                   sage storage loader
-[ node ] --------------> [ staging dir ] --------------------> [ osn ]
+[ node ] --------------> [ staging dir ] --------------------> [ storage ]
 ```
 
 # Architecture
@@ -15,15 +16,15 @@ The expected data flow is:
        scanner process walks staging dir
        and puts ready uploads into channel
 
-                                          +--> [ worker ] --> [     ]
-[ staging dir ] -----------> [|||] -------+--> [ worker ] --> [ osn ]
-                                          +--> [ worker ] --> [     ]
+                                          +--> [ worker ] --> [         ]
+[ staging dir ] -----------> [|||] -------+--> [ worker ] --> [ storage ]
+                                          +--> [ worker ] --> [         ]
 
                                         workers upload files to osn
                                         and clean them up afterwards
 ```
 
-# Integration testing with Minio
+# Integration testing for OSN with Minio
 
 We can stand up an integration testing environment using Docker Compose:
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The expected data flow is:
 [ staging dir ] -----------> [|||] -------+--> [ worker ] --> [ storage ]
                                           +--> [ worker ] --> [         ]
 
-                                        workers upload files to osn
+                                        workers upload files to STORAGE_TYPE
                                         and clean them up afterwards
 ```
 

--- a/file_uploader.go
+++ b/file_uploader.go
@@ -115,16 +115,7 @@ func (up *s3FileUploader) UploadFile(src, dst string, meta *MetaData) error {
 		return fmt.Errorf("s3 uploader failed: %s", err.Error())
 	}
 
-	// update metrics
-	// TODO(sean) make these non-global variables
-	// TODO(sean) think about splitting data vs meta files
-	// TODO(sean) figure out how to get VSN metadata for metrics
-	size := float64(stat.Size())
-	node := meta.Meta["node"]
-	uploadsProcessedTotal.Inc()
-	uploadsProcessedBytes.Add(size)
-	uploadsProcessedTotalByNode.WithLabelValues(node).Inc()
-	uploadsProcessedBytesByNode.WithLabelValues(node).Add(size)
+	uploadFileMetrics(stat, meta)
 
 	return nil
 }

--- a/file_uploader.go
+++ b/file_uploader.go
@@ -152,7 +152,7 @@ func (up *pelicanFileUploader) UploadFile(src, dst string, meta *MetaData) error
 	defer f.Close()
 
 	//Upload the file to Pelican
-	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/%s", up.config.Endpoint, up.config.Bucket), f)
+	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/%s/%s", up.config.Endpoint, up.config.Bucket, src), f)
 	if err != nil {return err}
 	req.Header.Set("Authorization", "Bearer "+string(up.jm.SignedJwtToken))
 	resp, err := up.client.Do(req)

--- a/file_uploader.go
+++ b/file_uploader.go
@@ -135,14 +135,10 @@ func (up *pelicanFileUploader) UploadFile(src, dst string, meta *MetaData) error
 
 	//Upload the file to Pelican
 	req, err := http.NewRequest("PUT", up.config.Endpoint, f)
-	if err != nil {
-		return err
-	}
+	if err != nil {return err}
 	req.Header.Set("Authorization", "Bearer "+string(up.SignedJwtToken))
 	resp, err := up.client.Do(req)
-	if err != nil {
-		return err
-	}
+	if err != nil {return err}
 	defer resp.Body.Close()
 
 	// Check response status

--- a/file_uploader.go
+++ b/file_uploader.go
@@ -134,6 +134,7 @@ func (up *pelicanFileUploader) UploadFile(src, dst string, meta *MetaData) error
 	defer f.Close()
 
 	//Upload the file to Pelican
+	//TODO: how can I attach metadata to the file? similiar to S3 - FL
 	req, err := http.NewRequest("PUT", up.config.Endpoint, f)
 	if err != nil {return err}
 	req.Header.Set("Authorization", "Bearer "+string(up.SignedJwtToken))

--- a/file_uploader.go
+++ b/file_uploader.go
@@ -152,7 +152,7 @@ func (up *pelicanFileUploader) UploadFile(src, dst string, meta *MetaData) error
 	defer f.Close()
 
 	//Upload the file to Pelican
-	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/%s/%s", up.config.Endpoint, up.config.Bucket, src), f)
+	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/%s/%s", up.config.Endpoint, up.config.Bucket, dst), f)
 	if err != nil {return err}
 	req.Header.Set("Authorization", "Bearer "+string(up.jm.SignedJwtToken))
 	resp, err := up.client.Do(req)

--- a/file_uploader.go
+++ b/file_uploader.go
@@ -91,9 +91,9 @@ func NewS3FileUploader(config S3FileUploaderConfig) (*s3FileUploader, error) {
 }
 
 //Initialize a new file uploader for Pelican by passing in a config, an initliaze JwtManager, and public key's id
-func NewPelicanFileUploader(config PelicanFileUploaderConfig, jm JwtManager, keyID *string) (*pelicanFileUploader, error) {
+func NewPelicanFileUploader(config PelicanFileUploaderConfig, jm JwtManager, keyID string) (*pelicanFileUploader, error) {
 	// Generate JWT token
-	token, err := jm.generateJwtToken(keyID)
+	token, err := jm.generateJwtToken(&keyID)
 	if err != nil {
 		return nil, fmt.Errorf("error generating JWT token: %v", err)
 	}

--- a/file_uploader.go
+++ b/file_uploader.go
@@ -21,6 +21,11 @@ type FileUploader interface {
 	UploadFile(src, dst string, meta *MetaData) error
 }
 
+type UploaderConfig interface {
+	GetEndpoint() string
+	GetBucket() string
+}
+
 type PelicanFileUploaderConfig struct {
 	Endpoint        string
 	Bucket          string
@@ -45,6 +50,26 @@ type pelicanFileUploader struct {
 	SignedJwtToken   string
 }
 
+// GetEndpoint returns the endpoint for S3.
+func (cfg S3FileUploaderConfig) GetEndpoint() string {
+	return cfg.Endpoint
+}
+
+// GetBucket returns the bucket name for S3.
+func (cfg S3FileUploaderConfig) GetBucket() string {
+	return cfg.Bucket
+}
+
+// GetEndpoint returns the endpoint for Pelican.
+func (cfg PelicanFileUploaderConfig) GetEndpoint() string {
+	return cfg.Endpoint
+}
+
+// GetBucket returns the bucket name for Pelican.
+func (cfg PelicanFileUploaderConfig) GetBucket() string {
+	return cfg.Bucket
+}
+
 func NewS3FileUploader(config S3FileUploaderConfig) (*s3FileUploader, error) {
 	disableSSL := !strings.HasPrefix(config.Endpoint, "https")
 
@@ -66,10 +91,9 @@ func NewS3FileUploader(config S3FileUploaderConfig) (*s3FileUploader, error) {
 }
 
 //Initialize a new file uploader for Pelican by passing in a config, an initliaze JwtManager, and public key's id
-func NewPelicanFileUploader(config PelicanFileUploaderConfig, jm JwtManager, ) (*pelicanFileUploader, error) {
+func NewPelicanFileUploader(config PelicanFileUploaderConfig, jm JwtManager, keyID *string) (*pelicanFileUploader, error) {
 	// Generate JWT token
-	keyID := "1234" // Replace with actual key ID from JWKS
-	token, err := jm.generateJwtToken(&keyID)
+	token, err := jm.generateJwtToken(keyID)
 	if err != nil {
 		return nil, fmt.Errorf("error generating JWT token: %v", err)
 	}

--- a/file_uploader.go
+++ b/file_uploader.go
@@ -152,7 +152,7 @@ func (up *pelicanFileUploader) UploadFile(src, dst string, meta *MetaData) error
 	defer f.Close()
 
 	//Upload the file to Pelican
-	req, err := http.NewRequest("PUT", up.config.Endpoint, f)
+	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/%s", up.config.Endpoint, up.config.Bucket), f)
 	if err != nil {return err}
 	req.Header.Set("Authorization", "Bearer "+string(up.jm.SignedJwtToken))
 	resp, err := up.client.Do(req)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/sagecontinuum/sage-storage-loader
 go 1.19
 
 require (
-	github.com/aws/aws-sdk-go v1.44.151
+	github.com/aws/aws-sdk-go v1.44.151 //TODO: remove
 	github.com/prometheus/client_golang v1.14.0
 )
 
@@ -11,6 +11,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/main.go
+++ b/main.go
@@ -182,7 +182,7 @@ func ScanAndProcessDir(ctx context.Context, config LoaderConfig) error {
 				}
 			case PelicanFileUploaderConfig:
 				jm := JwtManager{}
-				jm.init(mustGetEnv("JWT_PUBLIC_KEY_URL"),mustGetEnv("JWT_ISSUER_KEY_PATH"),mustGetEnv("JWT_PUBLIC_KEY_ID"))
+				jm.init(mustGetJwtManagerConfig())
 				uploader, err = NewPelicanFileUploader(cfg, jm)
 				if err != nil {
 					log.Fatalf("failed to create Pelican uploader: %s", err.Error())
@@ -241,12 +241,17 @@ func mustGetPelicanUploaderConfig() PelicanFileUploaderConfig {
 	}
 }
 
+//This function retrieves the env variables for configuring Jwt Manager and makes sure they exist.
+func mustGetJwtManagerConfig() (PublicKeyConfigURL string, IssuerKeyPath string, keyID string) {
+	return mustGetEnv("JWT_PUBLIC_KEY_URL"),mustGetEnv("JWT_ISSUER_KEY_PATH"),mustGetEnv("JWT_PUBLIC_KEY_ID")
+}
+
 func main() {
 	config := LoaderConfig{
 		NumWorkers:             mustParseInt(getEnv("LOADER_NUM_WORKERS", "3")),
 		DeleteFilesAfterUpload: mustParseBool(getEnv("LOADER_DELETE_FILES_AFTER_UPLOAD", "true")),
 		DataDir:                getEnv("LOADER_DATA_DIR", "/data"),
-		Config:                 mustGetPelicanUploaderConfig(), //DB type: Pelican
+		Config:                 mustGetPelicanUploaderConfig(), //Storage type: Pelican or OSN
 	}
 	log.Printf("using Pelican at %s in bucket %s",config.Config.GetEndpoint(), config.Config.GetBucket())
 

--- a/main.go
+++ b/main.go
@@ -243,7 +243,7 @@ func mustGetPelicanUploaderConfig() PelicanFileUploaderConfig {
 
 //This function retrieves the env variables for configuring Jwt Manager and makes sure they exist.
 func mustGetJwtManagerConfig() (PublicKeyConfigURL string, IssuerKeyPath string,keyID string) {
-	return mustGetEnv("JWT_PUBLIC_KEY_URL"),mustGetEnv("JWT_ISSUER_KEY_PATH"),mustGetEnv("JWT_PUBLIC_KEY_ID")
+	return mustGetEnv("JWT_PUBLIC_KEY_CONFIG_URL"),mustGetEnv("JWT_ISSUER_KEY_PATH"),mustGetEnv("JWT_PUBLIC_KEY_ID")
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -216,14 +216,21 @@ func mustGetS3UploaderConfig() S3FileUploaderConfig {
 	}
 }
 
+func mustGetPelicanUploaderConfig() PelicanFileUploaderConfig {
+	return PelicanFileUploaderConfig{
+		Endpoint:        mustGetEnv("LOADER_PELICAN_ENDPOINT"),
+		Bucket:          mustGetEnv("LOADER_PELICAN_BUCKET"),
+	}
+}
+
 func main() {
 	config := LoaderConfig{
 		NumWorkers:             mustParseInt(getEnv("LOADER_NUM_WORKERS", "3")),
 		DeleteFilesAfterUpload: mustParseBool(getEnv("LOADER_DELETE_FILES_AFTER_UPLOAD", "true")),
 		DataDir:                getEnv("LOADER_DATA_DIR", "/data"),
-		Config:                 mustGetS3UploaderConfig(),
+		Config:                 mustGetPelicanUploaderConfig(),
 	}
-	log.Printf("using s3 at %s@%s in bucket %s", config.Config.(S3FileUploaderConfig).AccessKeyID, config.Config.GetEndpoint(), config.Config.GetBucket())
+	log.Printf("using Pelican at %s in bucket %s",config.Config.GetEndpoint(), config.Config.GetBucket())
 
 	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt)
 

--- a/main.go
+++ b/main.go
@@ -201,7 +201,7 @@ func ScanAndProcessDir(ctx context.Context, config LoaderConfig) error {
 
 type LoaderConfig struct {
 	DataDir                string
-	S3Config               S3FileUploaderConfig
+	Config                 UploaderConfig
 	DeleteFilesAfterUpload bool
 	NumWorkers             int
 }
@@ -221,9 +221,9 @@ func main() {
 		NumWorkers:             mustParseInt(getEnv("LOADER_NUM_WORKERS", "3")),
 		DeleteFilesAfterUpload: mustParseBool(getEnv("LOADER_DELETE_FILES_AFTER_UPLOAD", "true")),
 		DataDir:                getEnv("LOADER_DATA_DIR", "/data"),
-		S3Config:               mustGetS3UploaderConfig(),
+		Config:                 mustGetS3UploaderConfig(),
 	}
-	log.Printf("using s3 at %s@%s in bucket %s", config.S3Config.AccessKeyID, config.S3Config.Endpoint, config.S3Config.Bucket)
+	log.Printf("using s3 at %s@%s in bucket %s", config.Config.(S3FileUploaderConfig).AccessKeyID, config.Config.GetEndpoint(), config.Config.GetBucket())
 
 	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt)
 

--- a/main.go
+++ b/main.go
@@ -182,8 +182,8 @@ func ScanAndProcessDir(ctx context.Context, config LoaderConfig) error {
 				}
 			case PelicanFileUploaderConfig:
 				jm := JwtManager{}
-				jm.init(mustGetEnv("JWT_PUBLIC_KEY_URL"),mustGetEnv("JWT_ISSUER_KEY_PATH"))
-				uploader, err = NewPelicanFileUploader(cfg, jm, mustGetEnv("JWT_PUBLIC_KEY_ID"))
+				jm.init(mustGetEnv("JWT_PUBLIC_KEY_URL"),mustGetEnv("JWT_ISSUER_KEY_PATH"),mustGetEnv("JWT_PUBLIC_KEY_ID"))
+				uploader, err = NewPelicanFileUploader(cfg, jm)
 				if err != nil {
 					log.Fatalf("failed to create Pelican uploader: %s", err.Error())
 				}

--- a/main.go
+++ b/main.go
@@ -189,7 +189,7 @@ func ScanAndProcessDir(ctx context.Context, config LoaderConfig) error {
 				}
 			default:
 				// Handle unknown or unsupported config type
-				log.Fatalf("unsupported uploader config type: %T", config.Config)
+				log.Fatalf("unsupported uploader config type: %T", cfg)
 			}
 
 			worker := &Worker{

--- a/test/pelican/docker-compose.yml
+++ b/test/pelican/docker-compose.yml
@@ -1,0 +1,19 @@
+# intended for local testing only, not deployment to production
+services:
+  loader:
+    image: waggle/sage-storage-loader:0.7.0
+    restart: always
+    ports:
+      - "127.0.0.1:8080:8080"
+    environment:
+      - STORAGE_TYPE=pelican
+      - LOADER_NUM_WORKERS=3
+      - LOADER_DATA_DIR=/data
+      - LOADER_PELICAN_ENDPOINT=https://nrdstor.nationalresearchplatform.org:8443/sage
+      - LOADER_PELICAN_BUCKET=test
+      - JWT_PUBLIC_KEY_URL=https://sagecontinuum.org/.well-known/openid-configuration
+      - JWT_ISSUER_KEY_PATH=/token/issuer-key.pem
+      - JWT_PUBLIC_KEY_ID=3cfa
+    volumes:
+      - "./test-data:/data"
+      - "./token:/token"

--- a/test/pelican/docker-compose.yml
+++ b/test/pelican/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - LOADER_DATA_DIR=/data
       - LOADER_PELICAN_ENDPOINT=https://nrdstor.nationalresearchplatform.org:8443/sage
       - LOADER_PELICAN_BUCKET=test
-      - JWT_PUBLIC_KEY_URL=https://sagecontinuum.org/.well-known/openid-configuration
+      - JWT_PUBLIC_KEY_CONFIG_URL=https://sagecontinuum.org/.well-known/openid-configuration
       - JWT_ISSUER_KEY_PATH=/token/issuer-key.pem
       - JWT_PUBLIC_KEY_ID=3cfa
     volumes:

--- a/test/pelican/docker-compose.yml
+++ b/test/pelican/docker-compose.yml
@@ -1,10 +1,8 @@
 # intended for local testing only, not deployment to production
 services:
   loader:
-    image: waggle/sage-storage-loader:0.7.0
+    build: ../..
     restart: always
-    ports:
-      - "127.0.0.1:8080:8080"
     environment:
       - STORAGE_TYPE=pelican
       - LOADER_NUM_WORKERS=3

--- a/test/s3/docker-compose.yml
+++ b/test/s3/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
     environment:
+      - STORAGE_TYPE=osn
       - LOADER_NUM_WORKERS=3
       - LOADER_DATA_DIR=/data
       - LOADER_S3_ENDPOINT=http://minio:9000

--- a/test/s3/docker-compose.yml
+++ b/test/s3/docker-compose.yml
@@ -1,7 +1,7 @@
 # intended for local testing only, not deployment to production
 services:
   loader:
-    build: .
+    build: ../..
     restart: always
     ports:
       - "127.0.0.1:8080:8080"

--- a/token.go
+++ b/token.go
@@ -140,7 +140,7 @@ func (jm *JwtManager) _signJwtToken(token *jwt.Token) (string, error) {
 		return "", fmt.Errorf("error signing token: %v", err)
 	}
 
-	fmt.Println("Generated JWT token:", signedToken)
+	fmt.Println("Generated JWT token using ",jm.issuerKeyPath)
 
 	return signedToken, nil
 }

--- a/token.go
+++ b/token.go
@@ -171,7 +171,7 @@ func (jm *JwtManager) generateJwtToken(keyID *string) (string, error) {
 		"ver":    "scitoken:2.0",
 		"sub":    "test",
 		"aud":    "ANY",
-		"scope":  "read:/test-write.txt write:/test-write.txt",
+		"scope":  "read:/ write:/",
 		"iat":    time.Now().Unix(),                // Issued At (current time)
 		"exp":    time.Now().Add(time.Hour).Unix(), // Expire time (1 hour from now)
 		"iss":    jm.publicKeyConfig.Issuer,

--- a/token.go
+++ b/token.go
@@ -41,7 +41,7 @@ type PublicKeyConfig struct {
 
 // init initializes the JwtManager with provided values & performs setup tasks
 func (jm *JwtManager) init(PublicKeyConfigURL, IssuerKeyPath string) error {
-	// Example default values or setup tasks
+	//init vars
 	jm.publicKeyConfigURL = PublicKeyConfigURL
 	jm.issuerKeyPath = IssuerKeyPath
 

--- a/token.go
+++ b/token.go
@@ -13,6 +13,8 @@ import (
 type JwtManager struct {
 	publicKeyConfigURL string
 	issuerKeyPath      string
+	PublicKeyID		   string
+	SignedJwtToken     string
 	publicKeyConfig    *PublicKeyConfig
 	jwks               *Jwks
 }
@@ -40,10 +42,11 @@ type PublicKeyConfig struct {
 }
 
 // init initializes the JwtManager with provided values & performs setup tasks
-func (jm *JwtManager) init(PublicKeyConfigURL, IssuerKeyPath string) error {
+func (jm *JwtManager) init(PublicKeyConfigURL, IssuerKeyPath string, keyID string) error {
 	//init vars
 	jm.publicKeyConfigURL = PublicKeyConfigURL
 	jm.issuerKeyPath = IssuerKeyPath
+	jm.PublicKeyID = keyID
 
 	// Fetch public key configuration
 	err := jm._fetchPublicKeyConfig()
@@ -56,6 +59,13 @@ func (jm *JwtManager) init(PublicKeyConfigURL, IssuerKeyPath string) error {
 	if err != nil {
 		return fmt.Errorf("error fetching JWKS: %v", err)
 	}
+
+	// Generate JWT token
+	token, err := jm.generateJwtToken(&keyID)
+	if err != nil {
+		return fmt.Errorf("error generating JWT token: %v", err)
+	}
+	jm.SignedJwtToken = token
 
 	return nil
 }

--- a/token.go
+++ b/token.go
@@ -137,6 +137,12 @@ func (jm *JwtManager) _signJwtToken(token *jwt.Token) (string, error) {
 
 // Creates a new signed jwt Token with the specified Claims
 func (jm *JwtManager) generateJwtToken(keyID *string) (string, error) {
+	// Check if jm is initialized
+	if jm.publicKeyConfig == nil || jm.jwks == nil {
+		return "", fmt.Errorf("JwtManager instance not properly initialized, use JwtManager.init()")
+	}
+
+	//find key
 	var selectedKey *key
 	found := false
 	for _, k := range jm.jwks.Keys {

--- a/token.go
+++ b/token.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// JwtManager manages operations related to JWT tokens
+type JwtManager struct {
+	publicKeyConfigURL string
+	issuerKeyPath      string
+	publicKeyConfig    *PublicKeyConfig
+	jwks               *Jwks
+}
+
+// keys in JWKSResponse
+type key struct {
+	Alg string `json:"alg"`
+	Crv string `json:"crv"`
+	Kid string `json:"kid"`
+	Kty string `json:"kty"`
+	Use string `json:"use"`
+	X   string `json:"x"`
+	Y   string `json:"y"`
+}
+
+// Jwks represents the JSON Web Key Set response structure
+type Jwks struct {
+	Keys []key `json:"keys"`
+}
+
+// PublicKeyConfig represents the public key config response structure
+type PublicKeyConfig struct {
+	Issuer   string `json:"issuer"`
+	Jwks_uri string `json:"jwks_uri"`
+}
+
+// init initializes the JwtManager with provided values & performs setup tasks
+func (jm *JwtManager) init(PublicKeyConfigURL, IssuerKeyPath string) error {
+	// Example default values or setup tasks
+	jm.publicKeyConfigURL = PublicKeyConfigURL
+	jm.issuerKeyPath = IssuerKeyPath
+
+	// Fetch public key configuration
+	err := jm._fetchPublicKeyConfig()
+	if err != nil {
+		return fmt.Errorf("error fetching public key config: %v", err)
+	}
+
+	// Fetch JWKS
+	err = jm._fetchJWKS()
+	if err != nil {
+		return fmt.Errorf("error fetching JWKS: %v", err)
+	}
+
+	return nil
+}
+
+// Retrieves our public key configuration
+func (jm *JwtManager) _fetchPublicKeyConfig() error {
+	// Perform HTTP GET request
+	resp, err := http.Get(jm.publicKeyConfigURL)
+	if err != nil {
+		return fmt.Errorf("error fetching public key config: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("non-OK HTTP status: %v", resp.Status)
+	}
+
+	// Decode response body into PublicKeyConfigResponse struct
+	var config PublicKeyConfig
+	if err := json.NewDecoder(resp.Body).Decode(&config); err != nil {
+		return fmt.Errorf("error decoding public key config JSON: %v", err)
+	}
+
+	jm.publicKeyConfig = &config
+
+	return nil
+}
+
+// Retrieves our SciToken public key
+func (jm *JwtManager) _fetchJWKS() error {
+	// Perform HTTP GET request
+	resp, err := http.Get(jm.publicKeyConfig.Jwks_uri)
+	if err != nil {
+		return fmt.Errorf("error fetching JWKS: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("non-OK HTTP status: %v", resp.Status)
+	}
+
+	// Decode response body into JWKSResponse struct
+	var jwks Jwks
+	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+		return fmt.Errorf("error decoding JWKS JSON: %v", err)
+	}
+
+	jm.jwks = &jwks
+
+	return nil
+}
+
+// Sign generated Jwt token, now you can use `signedToken` in your
+// HTTP requests with Authorization header as "Bearer <token>"
+func (jm *JwtManager) _signJwtToken(token *jwt.Token) (string, error) {
+
+	// Load private key from file (issuer-key.pem)
+	keyData, err := os.ReadFile(jm.issuerKeyPath)
+	if err != nil {
+		return "", fmt.Errorf("error reading private key file: %v", err)
+	}
+
+	// Parse the private key
+	key, err := jwt.ParseECPrivateKeyFromPEM(keyData)
+	if err != nil {
+		return "", fmt.Errorf("error parsing private key: %v", err)
+	}
+
+	// Sign the token with private key and get the complete signed token string
+	signedToken, err := token.SignedString(key)
+	if err != nil {
+		return "", fmt.Errorf("error signing token: %v", err)
+	}
+
+	fmt.Println("Generated JWT token:", signedToken)
+
+	return signedToken, nil
+}
+
+// Creates a new signed jwt Token with the specified Claims
+func (jm *JwtManager) generateJwtToken(keyID *string) (string, error) {
+	var selectedKey *key
+	found := false
+	for _, k := range jm.jwks.Keys {
+		if k.Kid == *keyID {
+			selectedKey = &k
+			found = true
+			break
+		}
+	}
+	if !found {
+		return "", fmt.Errorf("key with key_id %s not found in JWKS", *keyID)
+	}
+
+	// Claims for the JWT
+	claims := jwt.MapClaims{
+		"ver":    "scitoken:2.0",
+		"sub":    "test",
+		"aud":    "ANY",
+		"scope":  "read:/test-write.txt write:/test-write.txt",
+		"iat":    time.Now().Unix(),                // Issued At (current time)
+		"exp":    time.Now().Add(time.Hour).Unix(), // Expire time (1 hour from now)
+		"iss":    jm.publicKeyConfig.Issuer,
+		"key_id": selectedKey.Kid,
+	}
+
+	// Determine signing method based on alg
+	var signingMethod jwt.SigningMethod
+	switch selectedKey.Alg {
+	case "ES256":
+		signingMethod = jwt.SigningMethodES256
+	case "HS256":
+		signingMethod = jwt.SigningMethodHS256
+	case "PS256":
+		signingMethod = jwt.SigningMethodPS256
+	case "RS256":
+		signingMethod = jwt.SigningMethodRS256
+	default:
+		return "", fmt.Errorf("unsupported signing algorithm: %s", selectedKey.Alg)
+	}
+
+	// Create a new token
+	token := jwt.NewWithClaims(signingMethod, claims)
+
+	//sign token
+	signedToken, err := jm._signJwtToken(token)
+	if err != nil {
+		return "", fmt.Errorf("error signing token: %v", err)
+	}
+
+	return signedToken, nil
+}

--- a/worker.go
+++ b/worker.go
@@ -102,13 +102,13 @@ func (w *Worker) Process(job Job) error {
 	labelFilename := meta.Meta["filename"]
 	targetNameData := fmt.Sprintf("%d-%s", meta.Timestamp.UnixNano(), labelFilename)
 	targetNameMeta := fmt.Sprintf("%d-%s.meta", meta.Timestamp.UnixNano(), labelFilename)
-	s3path := fmt.Sprintf("node-data/%s/sage-%s-%s/%s", p.Namespace, p.Name, p.Version, p.NodeID)
+	path := fmt.Sprintf("node-data/%s/sage-%s-%s/%s", p.Namespace, p.Name, p.Version, p.NodeID)
 
-	if err := w.Uploader.UploadFile(dataPath, filepath.Join(s3path, targetNameData), &meta); err != nil {
+	if err := w.Uploader.UploadFile(dataPath, filepath.Join(path, targetNameData), &meta); err != nil {
 		return fmt.Errorf("error uploading data file: %s", err.Error())
 	}
 
-	if err := w.Uploader.UploadFile(metaPath, filepath.Join(s3path, targetNameMeta), &meta); err != nil {
+	if err := w.Uploader.UploadFile(metaPath, filepath.Join(path, targetNameMeta), &meta); err != nil {
 		return fmt.Errorf("error uploading meta file: %s", err.Error())
 	}
 
@@ -135,7 +135,7 @@ func (w *Worker) Process(job Job) error {
 		// before we can upload. In this case, that particular rsync will fail and then
 		// will be tried again later.
 		//
-		// In order for this to happen, the OSN loader would have to upload and clean up the
+		// In order for this to happen, the loader would have to upload and clean up the
 		// last staged item for a task right when that task is posting a new upload. This seems
 		// potentially rare enough that I'd opt for simpler, more robust cleanup logic for now.
 		for p := filepath.Dir(dataPath); filepath.Base(p) != "uploads"; p = filepath.Dir(p) {


### PR DESCRIPTION
I modified the code so that we can switch to Pelican via environment variables. This update is backwards compatible so the use of OSN is still possible. To switch storage types, STORAGE_TYPE env variable is used. The use of Pelican requires these env variables to be defined.

- STORAGE_TYPE: pelican or osn.
- LOADER_PELICAN_ENDPOINT: Pelican origin to use.
- LOADER_PELICAN_BUCKET: Directory to place data (mimics s3 bucket functionality for backwards compatibility).
- JWT_PUBLIC_KEY_CONFIG_URL: url to retrieve Jwt public key configuration.
- JWT_ISSUER_KEY_PATH: Issuer key cert to generate Jwt tokens.
- JWT_PUBLIC_KEY_ID: The id of the public key to use.

Existing env variables can still be used such as LOADER_NUM_WORKERS.